### PR TITLE
Removed Levenshtein distance's description

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -26,7 +26,7 @@ POST api/v1/merchants/{merchantId}/invoices
 |`ConsumerAlias`       ||`object`| **Required.** Mobile alias of the MobilePay user to be invoiced.                                                 |
 ||`Alias`|`string`|**Required.** Mobile phone number of the MobilePay user. Should start with a '+' sign and country phone code. <br/> E.g. +4512345678 or +35812345678                          |
 ||`AliasType`|`string` | **Required.** Alias type of the MobilePay user. <br/> Only value allowed is `Phone`.                                                            |
-|`ConsumerName`      |              |`string`      |**Required.** Full name of the MobilePay user. We validate it using [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) in order to ignore minor spelling mistakes.|
+|`ConsumerName`      |              |`string`      |**Required.** Full name of the MobilePay user.|
 |`TotalAmount`       |              |`decimal`     |**Required.** The requested amount to be paid. <br/> >0.00, decimals separated with a dot.|
 |`TotalVatAmount`    |              |`decimal`     |**Required.** VAT amount. Decimals separated with a dot.                                  |
 |`CountryCode`       |              |`string(2)`   |**Required.** Country code. Either `DK` or `FI` is allowed.                             |


### PR DESCRIPTION
We do not use it anymore, so there is no need to keep it in documentation.